### PR TITLE
chore: use one domain package

### DIFF
--- a/cmd/inspect/main.go
+++ b/cmd/inspect/main.go
@@ -5,8 +5,6 @@ import (
 	"os"
 
 	"github.com/dhis2-sre/im-inspector/pkg/config"
-	"github.com/dhis2-sre/im-inspector/pkg/handler"
-	"github.com/dhis2-sre/im-inspector/pkg/inspector"
 	"github.com/dhis2-sre/im-inspector/pkg/pod"
 	"github.com/dhis2-sre/rabbitmq/pgk/queue"
 )
@@ -24,14 +22,14 @@ func run() error {
 		return err
 	}
 
-	pg, err := pod.NewPodGetter()
+	pc, err := pod.NewClient()
 	if err != nil {
 		return err
 	}
 	producer := queue.ProvideProducer(config.RabbitMq.GetUrl())
-	inspector := inspector.NewInspector(pg, config.DeployableNamespaces,
-		handler.NewTTLDestroyHandler(&producer),
-		handler.NewIDHandler(),
+	inspector := pod.NewInspector(pc, config.DeployableNamespaces,
+		pod.NewTTLDestroyHandler(&producer),
+		pod.NewIDHandler(),
 	)
 
 	return inspector.Inspect()

--- a/cmd/inspect/main.go
+++ b/cmd/inspect/main.go
@@ -11,7 +11,7 @@ import (
 
 func main() {
 	if err := run(); err != nil {
-		fmt.Fprintf(os.Stderr, "%s\n", err)
+		fmt.Fprintf(os.Stderr, "%s\n", err) // nolint:errcheck
 		os.Exit(1)
 	}
 }

--- a/cmd/inspect/main.go
+++ b/cmd/inspect/main.go
@@ -17,7 +17,7 @@ func main() {
 }
 
 func run() error {
-	config, err := config.New()
+	cfg, err := config.New()
 	if err != nil {
 		return err
 	}
@@ -26,8 +26,8 @@ func run() error {
 	if err != nil {
 		return err
 	}
-	producer := queue.ProvideProducer(config.RabbitMq.GetUrl())
-	inspector := pod.NewInspector(pc, config.DeployableNamespaces,
+	producer := queue.ProvideProducer(cfg.RabbitMq.GetUrl())
+	inspector := pod.NewInspector(pc, cfg.DeployableNamespaces,
 		pod.NewTTLDestroyHandler(&producer),
 		pod.NewIDHandler(),
 	)

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -19,18 +19,22 @@ func New() (Config, error) {
 	if err != nil {
 		return Config{}, err
 	}
+
 	host, err := requireEnv("RABBITMQ_HOST")
 	if err != nil {
 		return Config{}, err
 	}
+
 	port, err := getEnvAsInt("RABBITMQ_PORT")
 	if err != nil {
 		return Config{}, err
 	}
+
 	usr, err := requireEnv("RABBITMQ_USERNAME")
 	if err != nil {
 		return Config{}, err
 	}
+
 	pw, err := requireEnv("RABBITMQ_PASSWORD")
 	if err != nil {
 		return Config{}, err

--- a/pkg/pod/client.go
+++ b/pkg/pod/client.go
@@ -10,11 +10,11 @@ import (
 	"k8s.io/client-go/tools/clientcmd"
 )
 
-type podGetter struct {
-	client *kubernetes.Clientset
+type client struct {
+	k8s *kubernetes.Clientset
 }
 
-func NewPodGetter() (*podGetter, error) {
+func NewClient() (*client, error) {
 	kubeConfigPath, _ := os.LookupEnv("KUBE_CONFIG_FILE")
 
 	restClientConfig, err := clientcmd.BuildConfigFromFlags("", kubeConfigPath)
@@ -22,22 +22,22 @@ func NewPodGetter() (*podGetter, error) {
 		return nil, err
 	}
 
-	client, err := kubernetes.NewForConfig(restClientConfig)
+	k8s, err := kubernetes.NewForConfig(restClientConfig)
 	if err != nil {
 		return nil, err
 	}
 
-	return &podGetter{client: client}, nil
+	return &client{k8s: k8s}, nil
 }
 
-func (pg *podGetter) Get(namespaces []string) ([]v1.Pod, error) {
+func (c *client) Get(namespaces []string) ([]v1.Pod, error) {
 	listOptions := metav1.ListOptions{
 		LabelSelector: "im=true",
 	}
 
 	var pods []v1.Pod
 	for _, namespace := range namespaces {
-		list, err := pg.client.CoreV1().Pods(namespace).List(context.TODO(), listOptions)
+		list, err := c.k8s.CoreV1().Pods(namespace).List(context.TODO(), listOptions)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/pod/handler.go
+++ b/pkg/pod/handler.go
@@ -1,10 +1,10 @@
-package handler
+package pod
 
 import (
 	v1 "k8s.io/api/core/v1"
 )
 
-type PodHandler interface {
+type Handler interface {
 	Supports() string
 	Handle(pod v1.Pod) error
 }

--- a/pkg/pod/idHandler.go
+++ b/pkg/pod/idHandler.go
@@ -1,4 +1,4 @@
-package handler
+package pod
 
 import (
 	"log"
@@ -8,7 +8,7 @@ import (
 
 type idHandler struct{}
 
-func NewIDHandler() PodHandler {
+func NewIDHandler() idHandler {
 	return idHandler{}
 }
 

--- a/pkg/pod/inspector.go
+++ b/pkg/pod/inspector.go
@@ -1,15 +1,14 @@
-package inspector
+package pod
 
 import (
 	"log"
 	"strings"
 
-	"github.com/dhis2-sre/im-inspector/pkg/handler"
 	v1 "k8s.io/api/core/v1"
 )
 
 type Inspector struct {
-	handlers   []handler.PodHandler
+	handlers   []Handler
 	namespaces []string
 	pods       podGetter
 }
@@ -18,7 +17,7 @@ type podGetter interface {
 	Get(namespaces []string) ([]v1.Pod, error)
 }
 
-func NewInspector(pods podGetter, namespaces []string, handlers ...handler.PodHandler) Inspector {
+func NewInspector(pods podGetter, namespaces []string, handlers ...Handler) Inspector {
 	return Inspector{
 		pods:       pods,
 		handlers:   handlers,
@@ -55,8 +54,8 @@ func (i Inspector) Inspect() error {
 	return nil
 }
 
-func (i Inspector) createHandlersByLabelMap() map[string][]handler.PodHandler {
-	handlerMap := make(map[string][]handler.PodHandler)
+func (i Inspector) createHandlersByLabelMap() map[string][]Handler {
+	handlerMap := make(map[string][]Handler)
 	for index := 0; index < len(i.handlers); index++ {
 		key := i.handlers[index].Supports()
 		handlerMap[key] = append(handlerMap[key], i.handlers[index])

--- a/pkg/pod/ttlDestroyHandler.go
+++ b/pkg/pod/ttlDestroyHandler.go
@@ -1,4 +1,4 @@
-package handler
+package pod
 
 import (
 	"log"
@@ -17,7 +17,7 @@ type ttlDestroyHandler struct {
 	producer *queue.Producer
 }
 
-func NewTTLDestroyHandler(producer *queue.Producer) PodHandler {
+func NewTTLDestroyHandler(producer *queue.Producer) ttlDestroyHandler {
 	return ttlDestroyHandler{producer}
 }
 


### PR DESCRIPTION
the im-inspector responsibility is inspecting pods

so it feels natural to have a pod package which contains the inspector,
handlers and handler implementations. All revolves around pods.

Creates readable types like pod.Handler, pod.Inspector

* its also custom to return the struct instead of interfaces in Go (except for error). Structs can be made private, returned and used wherever they satisfy an interface