### PR TITLE
chore: treat ttl label as seconds (previously it was a unix ts)

### DIFF
--- a/pkg/pod/ttlDestroyHandler.go
+++ b/pkg/pod/ttlDestroyHandler.go
@@ -47,6 +47,9 @@ func (t ttlDestroyHandler) Handle(pod v1.Pod) error {
 	return nil
 }
 
+// ttlBeforeNow return if creation time + ttl < now
+// creationTimestampLabel is a unix timestamp
+// ttlLabel is seconds
 func (t ttlDestroyHandler) ttlBeforeNow(creationTimestampLabel string, ttlLabel string) bool {
 	creationTimestamp, err := strconv.ParseInt(creationTimestampLabel, 10, 64)
 	if err != nil {

--- a/pkg/pod/ttlDestroyHandler.go
+++ b/pkg/pod/ttlDestroyHandler.go
@@ -28,7 +28,7 @@ func (t ttlDestroyHandler) Supports() string {
 func (t ttlDestroyHandler) Handle(pod v1.Pod) error {
 	log.Printf("TTL handler invoked: %s", pod.Name)
 
-	creationTimestamp := pod.Labels["im-creationTimestamp"]
+	creationTimestamp := pod.Labels["im-creation-timestamp"]
 	ttl := pod.Labels["im-ttl"]
 	if creationTimestamp == "" || ttl == "" {
 		log.Println("No creationTimestamp or TTL found")

--- a/pkg/pod/ttlDestroyHandler.go
+++ b/pkg/pod/ttlDestroyHandler.go
@@ -47,19 +47,19 @@ func (t ttlDestroyHandler) Handle(pod v1.Pod) error {
 	return nil
 }
 
-func (t ttlDestroyHandler) ttlBeforeNow(creationTimestamp string, ttl string) bool {
-	creationTimestampInt, err := strconv.ParseInt(creationTimestamp, 10, 64)
+func (t ttlDestroyHandler) ttlBeforeNow(creationTimestampLabel string, ttlLabel string) bool {
+	creationTimestamp, err := strconv.ParseInt(creationTimestampLabel, 10, 64)
 	if err != nil {
 		log.Println(err)
 		return false
 	}
 
-	ttlInt, err := strconv.ParseInt(ttl, 10, 64)
+	ttl, err := strconv.ParseInt(ttlLabel, 10, 64)
 	if err != nil {
 		log.Println(err)
 		return false
 	}
 
-	ttlTime := time.Unix(creationTimestampInt+ttlInt, 0).UTC()
+	ttlTime := time.Unix(creationTimestamp+ttl, 0).UTC()
 	return ttlTime.Before(time.Now())
 }

--- a/pkg/pod/ttlDestroyHandler.go
+++ b/pkg/pod/ttlDestroyHandler.go
@@ -48,7 +48,7 @@ func (t ttlDestroyHandler) Handle(pod v1.Pod) error {
 }
 
 // ttlBeforeNow return if creation time + ttl < now
-// creationTimestampLabel is a unix timestamp
+// creationTimestampLabel is a unix timestamp in seconds.
 // ttlLabel is seconds
 func (t ttlDestroyHandler) ttlBeforeNow(creationTimestampLabel string, ttlLabel string) bool {
 	creationTimestamp, err := strconv.ParseInt(creationTimestampLabel, 10, 64)

--- a/pkg/pod/ttlDestroyHandler.go
+++ b/pkg/pod/ttlDestroyHandler.go
@@ -49,7 +49,7 @@ func (t ttlDestroyHandler) Handle(pod v1.Pod) error {
 
 // ttlBeforeNow return if creation time + ttl < now
 // creationTimestampLabel is a unix timestamp in seconds.
-// ttlLabel is seconds
+// ttlLabel is the pods time-to-live in seconds.
 func (t ttlDestroyHandler) ttlBeforeNow(creationTimestampLabel string, ttlLabel string) bool {
 	creationTimestamp, err := strconv.ParseInt(creationTimestampLabel, 10, 64)
 	if err != nil {

--- a/pkg/pod/ttlDestroyHandler.go
+++ b/pkg/pod/ttlDestroyHandler.go
@@ -47,7 +47,7 @@ func (t ttlDestroyHandler) Handle(pod v1.Pod) error {
 	return nil
 }
 
-// ttlBeforeNow return if creation time + ttl < now
+// ttlBeforeNow returns true if the pod has expired according to its time to live.
 // creationTimestampLabel is a unix timestamp in seconds.
 // ttlLabel is the pods time-to-live in seconds.
 func (t ttlDestroyHandler) ttlBeforeNow(creationTimestampLabel string, ttlLabel string) bool {


### PR DESCRIPTION
Previously the ttl label was treated as a unix timestamp. This PR treats it as plain seconds thus making it easier to specify that an instance should live for... Say 5 minutes, which would added as 300 seconds.

The above is possible because the pods now also has a creation timestamp label which can be used as offset.

https://github.com/dhis2-sre/im-manager/pull/153 needs to be merged before this PR