### PR TITLE
Feature/test destroy handler

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.18
 
 require (
 	github.com/dhis2-sre/rabbitmq v0.2.2
+	github.com/stretchr/testify v1.8.1
 	k8s.io/api v0.27.0-alpha.1
 	k8s.io/apimachinery v0.27.0-alpha.1
 	k8s.io/client-go v0.27.0-alpha.1
@@ -28,8 +29,10 @@ require (
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
 	github.com/modern-go/reflect2 v1.0.2 // indirect
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/rabbitmq/amqp091-go v1.3.4 // indirect
 	github.com/spf13/pflag v1.0.5 // indirect
+	github.com/stretchr/objx v0.5.0 // indirect
 	golang.org/x/net v0.4.0 // indirect
 	golang.org/x/oauth2 v0.0.0-20220411215720-9780585627b5 // indirect
 	golang.org/x/sys v0.3.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -181,6 +181,7 @@ github.com/spf13/pflag v1.0.5/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An
 github.com/stoewer/go-strcase v1.2.0/go.mod h1:IBiWB2sKIp3wVVQ3Y035++gc+knqhUQag1KpM8ahLw8=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.4.0/go.mod h1:YvHI0jy2hoMjB+UWwv71VJQ9isScKT/TqJzVSSt89Yw=
+github.com/stretchr/objx v0.5.0 h1:1zr/of2m5FGMsad5YfcqgdqdWrIhu+EBEJRhR1U7z/c=
 github.com/stretchr/objx v0.5.0/go.mod h1:Yh+to48EsGEfYuaHDzXPcE3xhTkx73EhmCGUpEOglKo=
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
 github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=

--- a/pkg/pod/ttlDestroyHandler_test.go
+++ b/pkg/pod/ttlDestroyHandler_test.go
@@ -1,14 +1,15 @@
 package pod
 
 import (
+	"strconv"
+	"testing"
+	"time"
+
 	"github.com/dhis2-sre/rabbitmq/pgk/queue"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"strconv"
-	"testing"
-	"time"
 )
 
 type mockQueueProducer struct{ mock.Mock }

--- a/pkg/pod/ttlDestroyHandler_test.go
+++ b/pkg/pod/ttlDestroyHandler_test.go
@@ -1,0 +1,58 @@
+package pod
+
+import (
+	"github.com/dhis2-sre/rabbitmq/pgk/queue"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"strconv"
+	"testing"
+	"time"
+)
+
+type mockQueueProducer struct{ mock.Mock }
+
+func (m *mockQueueProducer) Produce(channel queue.Channel, payload any) {
+	m.Called(channel, payload)
+}
+
+func Test_ttlDestroyHandler_Handle(t *testing.T) {
+	producer := &mockQueueProducer{}
+	handler := NewTTLDestroyHandler(producer)
+	pod := v1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Labels: map[string]string{
+				"im-id":                 "1",
+				"im-creation-timestamp": strconv.Itoa(int(time.Now().Add(time.Minute * 5).Unix())),
+				"im-ttl":                "300",
+			},
+		},
+	}
+
+	err := handler.Handle(pod)
+
+	require.NoError(t, err)
+	producer.AssertExpectations(t)
+}
+
+func Test_ttlDestroyHandler_Handle_Destroy(t *testing.T) {
+	producer := &mockQueueProducer{}
+	var channel queue.Channel = "ttl-destroy"
+	producer.On("Produce", channel, struct{ ID uint }{ID: 1})
+	handler := NewTTLDestroyHandler(producer)
+	pod := v1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Labels: map[string]string{
+				"im-id":                 "1",
+				"im-creation-timestamp": strconv.Itoa(int(time.Now().Add(time.Minute * -5).Unix())),
+				"im-ttl":                "300",
+			},
+		},
+	}
+
+	err := handler.Handle(pod)
+
+	require.NoError(t, err)
+	producer.AssertExpectations(t)
+}


### PR DESCRIPTION
This PR adds two tests for the destroy handler

I had to introduce an interface in order to mock the queue producer

I also rewrite the ttlBeforeNow method so it doesn't include the string parsing. Basically I want it to return a boolean and since the string parsing operations could return an error I moved them into the main handle function.