### PR TITLE
chore: update Go, alpine, golangci-lint, pre-commit

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,7 +2,7 @@ ENVIRONMENT=<dev|production|etc>
 # Can be either "dev" or "prod"
 CLASSIFICATION=dev
 
-KUBE_CONFIG_FILE=/kubernetes/config
+KUBE_CONFIG_FILE=/kubernetes/config.yaml
 
 AWS_ACCESS_KEY_ID=<aws-access-key-id>
 AWS_SECRET_ACCESS_KEY=<aws-secret-access-key>

--- a/.github/workflows/build-test-deploy.yaml
+++ b/.github/workflows/build-test-deploy.yaml
@@ -19,7 +19,7 @@ concurrency:
 
 jobs:
   call-workflow:
-    uses: dhis2-sre/gha-workflows/.github/workflows/im-build-test-deploy.yaml@healthcheck
+    uses: dhis2-sre/gha-workflows/.github/workflows/im-build-test-deploy.yaml@master
     with:
       RUN_PID_1_TEST: false
       PROCESS_NAME: im-inspector

--- a/.github/workflows/build-test-deploy.yaml
+++ b/.github/workflows/build-test-deploy.yaml
@@ -19,10 +19,11 @@ concurrency:
 
 jobs:
   call-workflow:
-    uses: dhis2-sre/gha-workflows/.github/workflows/im-build-test-deploy.yaml@master
+    uses: dhis2-sre/gha-workflows/.github/workflows/im-build-test-deploy.yaml@healthcheck
     with:
       RUN_PID_1_TEST: false
       PROCESS_NAME: im-inspector
+      HEALTH_CHECK_ENDPOINT: ""
     secrets:
       DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
       DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}

--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,5 @@
 .env
 *.iml
 main
-k3s.yaml
 # decrypted secrets
 .dec

--- a/.gitignore
+++ b/.gitignore
@@ -2,5 +2,6 @@
 .env
 *.iml
 main
+k3s.yaml
 # decrypted secrets
 .dec

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,26 @@
+run:
+  timeout: 4m
+linters:
+  enable:
+    - errcheck
+    - forbidigo
+    - gocritic
+    - gosec
+    - gosimple
+    - govet
+    - ineffassign
+    - sloglint
+    - staticcheck
+    - unused
+linters-settings:
+  forbidigo:
+    forbid:
+      - p: ^log\.Print.*$
+        msg: Use log/slog to log
+      - p: ^log\.Fatal.*$
+        msg: Only main should call os.Exit(). Return an error instead
+  sloglint:
+    no-global: "all"
+    static-msg: true
+    key-naming-case: camel
+    context: scope

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -11,15 +11,12 @@ repos:
         args:
           - "-w"
       - id: go-mod-tidy
-      - id: go-sec-repo-mod
 
   - repo: https://github.com/golangci/golangci-lint
-    rev: v1.51.1
+    rev: v1.59.1
     hooks:
       - id: golangci-lint
-        args:
-          - "--timeout=3m"
-          - "--enable=gocritic"
+        args: [--verbose]
 
   - repo: https://github.com/commitizen-tools/commitizen
     rev: v2.24.0

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.21.3-alpine3.18 AS build
+FROM golang:1.22.4-alpine3.20 AS build
 
 # https://github.com/kubernetes-sigs/aws-iam-authenticator/releases/
 ARG AWS_IAM_AUTHENTICATOR_VERSION=0.6.11
@@ -19,7 +19,7 @@ RUN go mod download -x
 COPY . .
 RUN go build -o /app/im-inspector ./cmd/inspect
 
-FROM alpine:3.18
+FROM alpine:3.20
 RUN apk --no-cache -U upgrade
 COPY --from=build /usr/bin/aws-iam-authenticator /usr/bin/aws-iam-authenticator
 WORKDIR /app

--- a/Makefile
+++ b/Makefile
@@ -23,12 +23,7 @@ push-docker-image:
 	IMAGE_TAG=$(tag) docker compose push prod
 
 smoke-test:
-	docker compose up -d rabbitmq kubernetes
-	sleep 5
-	docker compose cp kubernetes:/tmp/kubernetes/k3s.yaml ./k3s.yaml
-	yq e -i ".clusters[0].cluster.server = \"https://kubernetes:6443\"" ./k3s.yaml
-	IMAGE_TAG=$(tag) docker compose up -d prod
-	docker compose logs -f prod
+	docker compose up prod
 
 test: clean
 	docker compose run --no-deps test

--- a/Makefile
+++ b/Makefile
@@ -3,6 +3,7 @@ clean-cmd = docker compose down --remove-orphans --volumes
 
 init:
 	pip install pre-commit
+	pre-commit clean
 	pre-commit install --install-hooks --overwrite
 
 	go install github.com/direnv/direnv@latest
@@ -10,11 +11,10 @@ init:
 
 	go install golang.org/x/tools/cmd/goimports@latest
 
-	go install github.com/securego/gosec/v2/cmd/gosec@latest
-	gosec --version
+	go install golang.org/x/tools/cmd/goimports@latest
 
 check:
-	pre-commit run --all-files --show-diff-on-failure
+	pre-commit run --verbose --all-files --show-diff-on-failure
 
 docker-image:
 	IMAGE_TAG=$(tag) docker compose build prod

--- a/Makefile
+++ b/Makefile
@@ -23,7 +23,9 @@ push-docker-image:
 	IMAGE_TAG=$(tag) docker compose push prod
 
 smoke-test:
-	docker compose up prod
+	docker compose up -d rabbitmq kubernetes
+	sleep 5
+	IMAGE_TAG=$(tag) docker compose up -d prod
 
 test: clean
 	docker compose run --no-deps test

--- a/Makefile
+++ b/Makefile
@@ -23,8 +23,6 @@ push-docker-image:
 	IMAGE_TAG=$(tag) docker compose push prod
 
 smoke-test:
-	docker compose up -d rabbitmq kubernetes
-	sleep 5
 	IMAGE_TAG=$(tag) docker compose up -d prod
 
 test: clean

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,7 +15,7 @@ services:
     env_file:
       - .env
     volumes:
-      - kubernetes-config:/kubernetes:z
+      - kubernetes-config:/kubernetes
     depends_on:
       rabbitmq:
         condition: service_healthy
@@ -62,7 +62,7 @@ services:
       - "127.0.0.1:6443:6443" # Kubernetes API Server
     volumes:
       - k3s-server:/var/lib/rancher/k3s
-      - kubernetes-config:/tmp/kubernetes:z
+      - kubernetes-config:/tmp/kubernetes
     environment:
       K3S_KUBECONFIG_OUTPUT: /tmp/kubernetes/k3s.yaml
       K3S_KUBECONFIG_MODE: 666
@@ -76,7 +76,7 @@ services:
   init-kubernetes-config:
     image: busybox
     volumes:
-      - kubernetes-config:/tmp/kubernetes:z
+      - kubernetes-config:/tmp/kubernetes
     working_dir: /tmp/kubernetes
     command: >
       sh -c "cp k3s.yaml config.yaml && sed -i 's/127.0.0.1/kubernetes/g' config.yaml"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,13 +2,12 @@ x-service: &common-dev-test
   build:
     context: .
     target: build
-  working_dir: /src
-  volumes:
-    - .:/src
   env_file:
     - .env
+  volumes:
+    - .:/src
+  working_dir: /src
 
-version: "3.6"
 services:
   prod:
     image: dhis2/im-inspector:${IMAGE_TAG:-latest}
@@ -16,41 +15,39 @@ services:
     env_file:
       - .env
     volumes:
-      - ./k3s.yaml:/kubernetes/config
+      - kubernetes-config:/kubernetes:z
+    depends_on:
+      rabbitmq:
+        condition: service_healthy
+      kubernetes:
+        condition: service_healthy
+      init-kubernetes-config:
+        condition: service_completed_successfully
 
   test:
     command: /bin/sh -c 'go test -v ./...'
     <<: *common-dev-test
 
   rabbitmq:
-    image: rabbitmq:3-management-alpine
+    image: bitnami/rabbitmq:3.13
     ports:
-      - "5672:5672"
-      - "15672:15672"
-
-  database:
-    image: postgres:13-alpine
-    ports:
-      - "5432:5432"
-    volumes:
-      - instance-manager-database:/var/lib/postgresql/data
+      - "127.0.0.1:5672:5672" # regular AMQP
+      - "127.0.0.1:15672:15672" # management UI
     environment:
-      POSTGRES_USER: ${DATABASE_USERNAME}
-      POSTGRES_PASSWORD: ${DATABASE_PASSWORD}
-      POSTGRES_DB: ${DATABASE_NAME}
-
-  kubernetes-init:
-    build:
-      dockerfile: Dockerfile.init
-    volumes:
-      - kubernetes-config:/tmp/kubernetes:z
-      - ./scripts/init-local.sh:/scripts/init-local.sh
-    command: /scripts/init-local.sh
-    env_file:
-      - .env
+      RABBITMQ_USERNAME: ${RABBITMQ_USERNAME}
+      RABBITMQ_PASSWORD: ${RABBITMQ_PASSWORD}
+      RABBITMQ_MANAGEMENT_ALLOW_WEB_ACCESS: true
+      RABBITMQ_DISK_FREE_ABSOLUTE_LIMIT: "100MB"
+      RABBITMQ_PLUGINS: "rabbitmq_management,rabbitmq_management_agent,rabbitmq_stream,rabbitmq_stream_management"
+    healthcheck:
+      # https://www.rabbitmq.com/docs/monitoring#stage-3
+      test: rabbitmq-diagnostics -q check_running && rabbitmq-diagnostics -q check_local_alarms
+      interval: 5s
+      timeout: 3s
+      retries: 5
 
   kubernetes:
-    image: rancher/k3s:v1.21.3-k3s1
+    image: rancher/k3s:v1.29.4-k3s1
     privileged: true
     command: server
     tmpfs:
@@ -62,16 +59,31 @@ services:
         soft: 65535
         hard: 65535
     ports:
-      - "6443:6443"
-      - "443:443"
-      - "80:80"
+      - "127.0.0.1:6443:6443" # Kubernetes API Server
     volumes:
-      - ./k3s-storage:/var/lib/rancher/k3s/storage:Z
+      - k3s-server:/var/lib/rancher/k3s
       - kubernetes-config:/tmp/kubernetes:z
     environment:
       K3S_KUBECONFIG_OUTPUT: /tmp/kubernetes/k3s.yaml
       K3S_KUBECONFIG_MODE: 666
+    healthcheck:
+      test: ["CMD-SHELL", "kubectl --kubeconfig /tmp/kubernetes/k3s.yaml version"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 10s
+
+  init-kubernetes-config:
+    image: busybox
+    volumes:
+      - kubernetes-config:/tmp/kubernetes:z
+    working_dir: /tmp/kubernetes
+    command: >
+      sh -c "cp k3s.yaml config.yaml && sed -i 's/127.0.0.1/kubernetes/g' config.yaml"
+    depends_on:
+      kubernetes:
+        condition: service_healthy
 
 volumes:
-  instance-manager-database: { }
+  k3s-server: {}
   kubernetes-config: { }


### PR DESCRIPTION
Align pre-commit, golangci-lint and Go and alpine version with the changes in im-manager
* https://github.com/dhis2-sre/im-manager/pull/804
* https://github.com/dhis2-sre/im-manager/pull/806
* https://github.com/dhis2-sre/im-manager/pull/803

- Update kubernetes version so it aligns with the one in our cluster.
- Remove unused DB service from docker-compose.
- Use init style container to setup k8s config for prod service. This way we can do `docker compose up` without using any `sleep`.
- Check that im-inspector exited with status code 0 https://github.com/dhis2-sre/gha-workflows/pull/61.